### PR TITLE
Add configuration for Filtering and Redaction

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,468 @@
+# Configuration Guide
+
+## Configuration Reference
+
+### Configuration Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Exclude` | `string[]` | `[]` | Regex patterns for keys to exclude entirely |
+| `Redact` | `RedactionRule[]` | `[]` | Rules for redacting sensitive values |
+| `RedactionCharacter` | `string` | `•` | Character to use for redaction |
+| `PartialVisibleChars` | `int` | `4` | Number of characters to show at start/end in Partial mode |
+| `ExcludeEmptyValues` | `bool` | `false` | Whether to exclude keys with null or empty values |
+
+### Exclusion Patterns
+
+The `Exclude` array accepts regex patterns to completely remove configuration keys from the display. These keys won't appear in the dashboard at all.
+
+```json
+"Exclude": [
+  "^APPSETTING_",            // Exclude environment variables starting with APPSETTING_
+  "^AZURE_",                 // Exclude Azure-related environment variables
+  "^EnvironmentInspect",     // Hide the EnvironmentInspect config itself
+  "^\\$schema$"              // Hide the $schema property
+]
+```
+
+### Redaction Rules
+
+The `Redact` array defines rules for masking sensitive values. Rules are processed in order, and the **first matching rule is applied**.
+
+#### Redaction Modes
+
+**1. Full Redaction** - Completely masks the value:
+```json
+{
+  "Key": ".*Password$",
+  "RedactionMode": "Full"
+}
+```
+Result: `••••••••`
+
+**2. Partial Redaction** - Shows start and end characters:
+```json
+{
+  "Key": "Umbraco:CMS:Global:Id",
+  "RedactionMode": "Partial"
+}
+```
+Result: `2ebd••••eac5` (shows first 4 and last 4 chars by default)
+
+**3. Advanced Redaction** - Custom redaction with options:
+
+*Option A: Keep specific characters*
+```json
+{
+  "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+  "RedactionMode": "Advanced",
+  "RedactionOptions": {
+    "KeepFirst": 2,
+    "KeepLast": 2
+  }
+}
+```
+Input: `1234567890`  
+Result: `12••••90`
+
+*Option B: Extract and redact nested keys (for connection strings)*
+```json
+{
+  "Key": "ConnectionStrings:.*",
+  "RedactionMode": "Advanced",
+  "RedactionOptions": {
+    "Keys": [ "Password", "PWD" ],
+    "KeepFirst": 2,
+    "KeepLast": 2
+  }
+}
+```
+Input: `Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R9K8sS*@G2$JmpeQs($;Connection Timeout=120;`  
+Result: `Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R••••($;Connection Timeout=120;`
+
+#### Provider-Based Redaction
+
+Redact all values from specific configuration providers using provider matching properties. You can use `Provider` (full name), `ProviderType` (class name), or `ProviderSource` (file name).
+
+**Understanding Provider Names**
+
+ASP.NET Core configuration providers have verbose names that include the class name and additional context. Here are some real examples:
+
+- `JsonConfigurationProvider for 'appsettings.json' (Optional)`
+- `JsonConfigurationProvider for 'appsettings.Development.json' (Optional)*`
+- `EnvironmentVariablesConfigurationProvider`
+- `AzureKeyVaultConfigurationProvider`
+- `CommandLineConfigurationProvider`
+
+The asterisk `*` suffix indicates the active provider for a key when multiple providers define the same key.
+
+**Matching Options**
+
+**Option 1: Match by source file (simplest)**
+
+```json
+{
+  "ProviderSource": "appsettings.Development.json",
+  "RedactionMode": "Partial"
+}
+```
+
+Match all development configuration files:
+
+```json
+{
+  "ProviderSource": ".*Development.*",
+  "RedactionMode": "Partial"
+}
+```
+
+**Option 2: Match by provider type**
+
+```json
+{
+  "ProviderType": "AzureKeyVaultConfigurationProvider",
+  "RedactionMode": "Full"
+}
+```
+
+Match all Azure-related providers:
+
+```json
+{
+  "ProviderType": ".*Azure.*",
+  "RedactionMode": "Full"
+}
+```
+
+**Option 3: Match by full provider name (for complete control)**
+
+```json
+{
+  "Provider": "JsonConfigurationProvider for 'appsettings\\.Development\\.json'.*",
+  "RedactionMode": "Partial"
+}
+```
+
+**Option 4: Combine multiple properties (AND logic)**
+
+All specified properties must match:
+
+```json
+{
+  "ProviderType": "JsonConfigurationProvider",
+  "ProviderSource": ".*Development.*",
+  "RedactionMode": "Partial"
+}
+```
+
+### Visual Indicators
+
+The dashboard displays emoji indicators for redacted values:
+
+| Emoji | Mode | Description |
+|-------|------|-------------|
+| 🔒 | Full | Value is completely redacted |
+| 👁️ | Partial | Value is partially visible |
+| 🔐 | Advanced | Value uses custom redaction rules |
+
+## Configuration Examples
+
+### Basic Example
+
+Hide internal configuration and redact all passwords:
+
+```json
+{
+  "EnvironmentInspect": {
+    "Exclude": [
+      "^APPSETTING_",
+      "^AZURE_",
+      "^EnvironmentInspect",
+      "^\\$schema$"
+    ],
+    "Redact": [
+      {
+        "Key": ".*Password$",
+        "RedactionMode": "Full"
+      }
+    ]
+  }
+}
+```
+
+### Production-Ready Example
+
+Comprehensive configuration for a production environment:
+
+```json
+{
+  "EnvironmentInspect": {
+    "Exclude": [
+      "^APPSETTING_",
+      "^AZURE_",
+      "^EnvironmentInspect",
+      "^\\$schema$"
+    ],
+    "Redact": [
+      {
+        "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": "ConnectionStrings:.*",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ "Password", "PWD", "User Id", "UID" ],
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": ".*Password$",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*Secret.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*ApiKey.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*Token.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": "AzureKeyVaultConfigurationProvider",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": ".*Azure.*",
+        "RedactionMode": "Full"
+      }
+    ],
+    "RedactionCharacter": "•",
+    "PartialVisibleChars": 4,
+    "ExcludeEmptyValues": false
+  }
+}
+```
+
+### Advanced Connection String Redaction
+
+Extract and redact only sensitive parts of connection strings:
+
+```json
+{
+  "EnvironmentInspect": {
+    "Redact": [
+      {
+        "Key": "ConnectionStrings:.*",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ 
+            "Password", 
+            "PWD", 
+            "User Id", 
+            "UID",
+            "password",
+            "pwd",
+            "user id",
+            "uid"
+          ],
+          "KeepFirst": 3,
+          "KeepLast": 3
+        }
+      }
+    ]
+  }
+}
+```
+
+**Input:**
+```
+Server=myserver.database.windows.net;Database=mydb;User ID=myuser;Password=MyP@ssw0rd123;
+```
+
+**Output:**
+```
+Server=myserver.database.windows.net;Database=mydb;User ID=myu•••ser;Password=MyP•••123;
+```
+
+### Provider-Based Redaction Examples
+
+Redact all values from specific configuration providers:
+
+```json
+{
+  "EnvironmentInspect": {
+    "Redact": [
+      {
+        "ProviderType": "AzureKeyVaultConfigurationProvider",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": "AzureAppConfigurationProvider",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": "EnvironmentVariablesConfigurationProvider",
+        "RedactionMode": "Partial"
+      },
+      {
+        "ProviderSource": ".*Development.*",
+        "RedactionMode": "Partial"
+      }
+    ]
+  }
+}
+```
+
+### Development vs Production Configuration
+
+**appsettings.json** (base configuration):
+```json
+{
+  "EnvironmentInspect": {
+    "Exclude": [
+      "^APPSETTING_",
+      "^AZURE_",
+      "^EnvironmentInspect",
+      "^\\$schema$"
+    ],
+    "RedactionCharacter": "•",
+    "PartialVisibleChars": 4
+  }
+}
+```
+
+**appsettings.Production.json** (production overrides):
+```json
+{
+  "EnvironmentInspect": {
+    "Redact": [
+      {
+        "Key": ".*Password$",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*Secret.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": "ConnectionStrings:.*",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ "Password", "PWD", "User Id" ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Regex Pattern Tips
+
+### Common Patterns
+
+- `^APPSETTING_` - Starts with "APPSETTING_"
+- `.*Password$` - Ends with "Password"
+- `.*Secret.*` - Contains "Secret"
+- `^ConnectionStrings:` - Starts with "ConnectionStrings:"
+- `Umbraco:CMS:.*:.*Password` - Umbraco CMS passwords at any depth
+
+### Escaping Special Characters
+
+In JSON, backslashes must be escaped:
+
+- `.` → `\\.` (literal dot)
+- `$` → `\\$` (literal dollar sign)
+- `^` → `^` (start of string - no escape needed)
+
+### Testing Regex
+
+Use [regex101.com](https://regex101.com/) with the "ECMAScript (JavaScript)" flavor to test your patterns.
+
+## Rule Priority
+
+Redaction rules are processed **in order**, and the **first matching rule is applied**. Place more specific rules before general ones:
+
+**✅ Correct Order:**
+```json
+{
+  "Redact": [
+    {
+      "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+      "RedactionMode": "Partial"
+    },
+    {
+      "Key": ".*Password$",
+      "RedactionMode": "Full"
+    }
+  ]
+}
+```
+
+**❌ Incorrect Order:**
+```json
+{
+  "Redact": [
+    {
+      "Key": ".*Password$",
+      "RedactionMode": "Full"
+    },
+    {
+      "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+      "RedactionMode": "Partial"
+    }
+  ]
+}
+```
+
+In the incorrect example, the specific Umbraco password rule will never be applied because `.*Password$` matches first.
+
+## Visual Indicators
+
+The dashboard displays emoji indicators for redacted values:
+
+| Emoji | Mode | Description |
+|-------|------|-------------|
+| 🔒 | Full | Value is completely redacted |
+| 👁️ | Partial | Value is partially visible |
+| 🔐 | Advanced | Value uses custom redaction rules |
+
+## Best Practices
+
+1. **Test in Development**: Verify your exclusion and redaction rules work as expected before deploying to production
+2. **Document Your Patterns**: Add comments in your configuration to explain complex regex patterns
+3. **Review Regularly**: As your application grows, review and update your configuration rules
+4. **Use Environment-Specific Files**: Apply stricter redaction in production environments
+5. **Monitor Performance**: If you have thousands of configuration keys, use exclusion patterns to reduce the dataset
+6. **Validate Regex**: Invalid regex patterns will be logged as warnings but won't break the application
+
+## Troubleshooting
+
+### Rule Not Matching
+
+- Check regex syntax - use [regex101.com](https://regex101.com/)
+- Remember to escape backslashes in JSON: `\.` becomes `\\.`
+- Check rule order - a previous rule may be matching first
+
+### Too Much/Too Little Visible
+
+Adjust the `PartialVisibleChars` setting or use `Advanced` mode with `KeepFirst`/`KeepLast` options.
+
+### Performance Issues
+
+- Use `Exclude` patterns to remove large sections of configuration
+- Set `ExcludeEmptyValues: true` to reduce empty entries
+- Cache is automatically cleared when configuration changes
+
+## Support
+
+For issues, questions, or contributions, visit the [GitHub repository](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect).

--- a/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
+++ b/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
@@ -36,6 +36,55 @@
   },
   "ConnectionStrings": {
     "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
+    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite",
+    "umbracoDbDSN_Azure": "Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R9K8sS*@G2$JmpeQs($;Connection Timeout=120;",
+    "umbracoDbDSN_ProviderName_Azzure": "Microsoft.Data.SqlClient"
+  },
+  "EnvironmentInspect": {
+    "Exclude": [
+      "^APPSETTING_",
+      "^AZURE_",
+      "^EnvironmentInspect",
+      "^\\$schema$"
+    ],
+    "Redact": [
+      {
+        "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": "ConnectionStrings:.*",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ "Password", "PWD" ],
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": ".*Password$",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*Secret.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": "JsonConfigurationProvider",
+        "ProviderSource": ".*Development.*",
+        "RedactionMode": "Partial"
+      },
+      {
+        "ProviderType": "AzureKeyVaultConfigurationProvider",
+        "RedactionMode": "Full"
+      }
+    ],
+    "RedactionCharacter": "•",
+    "PartialVisibleChars": 4,
+    "ExcludeEmptyValues": false
   }
 }

--- a/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
+++ b/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
@@ -34,11 +34,12 @@
       }
     }
   },
+  "ARemoteAPIKey": "aaaa1111-2222-3333-4444-5555aaaa1111",
   "ConnectionStrings": {
     "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite",
     "umbracoDbDSN_Azure": "Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R9K8sS*@G2$JmpeQs($;Connection Timeout=120;",
-    "umbracoDbDSN_ProviderName_Azzure": "Microsoft.Data.SqlClient"
+    "umbracoDbDSN_ProviderName_Azure": "Microsoft.Data.SqlClient"
   },
   "EnvironmentInspect": {
     "Exclude": [
@@ -64,6 +65,10 @@
           "KeepFirst": 2,
           "KeepLast": 2
         }
+      },
+      {
+        "Key":"ARemoteAPIKey",
+        "RedactionMode": "Full"
       },
       {
         "Key": ".*Password$",

--- a/Cultiv.EnvironmentInspect/Client/src/dashboards/dashboard.ts
+++ b/Cultiv.EnvironmentInspect/Client/src/dashboards/dashboard.ts
@@ -19,6 +19,19 @@ export class EnvironmentInspectDashboardElement extends UmbElementMixin(LitEleme
     return this.displayedCount < this.environmentVariables.length;
   }
 
+  getRedactionEmoji(redactedMode?: string | null): string {
+    switch (redactedMode) {
+      case 'Full':
+        return '🔒'; // Full redaction - locked
+      case 'Partial':
+        return '👁️'; // Partial redaction - eye (partial visibility)
+      case 'Advanced':
+        return '🔐'; // Advanced redaction - locked with key (custom rules)
+      default:
+        return ''; // No redaction
+    }
+  }
+
   render() {
     return html`
       ${when(this.isLoading, 
@@ -40,10 +53,13 @@ export class EnvironmentInspectDashboardElement extends UmbElementMixin(LitEleme
                   (item) => item.key,
                   (item) => html`
                     <uui-table-row>
-                      <uui-table-cell clip-text="">${item.key}</uui-table-cell>
-                      <uui-table-cell clip-text="">
+                      <uui-table-cell class="key-cell">${item.key}</uui-table-cell>
+                      <uui-table-cell class="value-cell">
                         <em style="font-size: 0.8em">${item.provider}</em>
                         <br/>
+                        ${when(item.redactedMode, () => html`
+                          <span style="margin-right: 0.25rem;" title="Redacted: ${item.redactedMode}">${this.getRedactionEmoji(item.redactedMode)}</span>
+                        `)}
                         ${item.value}
                       </uui-table-cell>
                     </uui-table-row>
@@ -146,6 +162,14 @@ export class EnvironmentInspectDashboardElement extends UmbElementMixin(LitEleme
         font-size: 0.9em;
         background-color: var(--uui-color-surface);
         border-top: 1px solid var(--uui-color-border);
+      }
+
+      uui-table-cell.key-cell,
+      uui-table-cell.value-cell {
+        white-space: normal;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+        vertical-align: top;
       }
     `,
   ];

--- a/Cultiv.EnvironmentInspect/Composers/CultivEnvironmentInspectComposer.cs
+++ b/Cultiv.EnvironmentInspect/Composers/CultivEnvironmentInspectComposer.cs
@@ -13,6 +13,7 @@ using Umbraco.Cms.Api.Management.OpenApi;
 using Umbraco.Cms.Api.Common.OpenApi;
 using Umbraco.Cms.Core.Notifications;
 
+using Cultiv.EnvironmentInspect.Configuration;
 using Cultiv.EnvironmentInspect.NotificationHandlers;
 using Cultiv.EnvironmentInspect.Services;
 
@@ -22,6 +23,10 @@ namespace Cultiv.EnvironmentInspect.Composers
     {
         public void Compose(IUmbracoBuilder builder)
         {
+            // Register configuration options
+            builder.Services.Configure<EnvironmentInspectOptions>(
+                builder.Config.GetSection("EnvironmentInspect"));
+
             // Register the environment inspect service
             builder.Services.AddSingleton<IEnvironmentInspectService, EnvironmentInspectService>();
             builder.Services.AddSingleton<IOperationIdHandler, CustomOperationHandler>();

--- a/Cultiv.EnvironmentInspect/Configuration/EnvironmentInspectOptions.cs
+++ b/Cultiv.EnvironmentInspect/Configuration/EnvironmentInspectOptions.cs
@@ -1,0 +1,112 @@
+namespace Cultiv.EnvironmentInspect.Configuration;
+
+/// <summary>
+/// Configuration options for the Environment Inspector
+/// </summary>
+public class EnvironmentInspectOptions
+{
+    /// <summary>
+    /// List of regex patterns for configuration keys to exclude entirely
+    /// </summary>
+    public List<string> Exclude { get; set; } = new();
+
+    /// <summary>
+    /// List of redaction rules to apply to configuration values
+    /// </summary>
+    public List<RedactionRule> Redact { get; set; } = new();
+
+    /// <summary>
+    /// Character to use for redaction (default: •)
+    /// </summary>
+    public string RedactionCharacter { get; set; } = "•";
+
+    /// <summary>
+    /// Number of characters to show in Partial redaction mode (default: 4)
+    /// </summary>
+    public int PartialVisibleChars { get; set; } = 4;
+
+    /// <summary>
+    /// Whether to exclude keys with null or empty values (default: false)
+    /// </summary>
+    public bool ExcludeEmptyValues { get; set; } = false;
+}
+
+/// <summary>
+/// A rule for redacting configuration values
+/// </summary>
+public class RedactionRule
+{
+    /// <summary>
+    /// Regex pattern for matching configuration keys (mutually exclusive with Provider)
+    /// </summary>
+    public string? Key { get; set; }
+
+    /// <summary>
+    /// Provider name to match (mutually exclusive with Key)
+    /// </summary>
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Provider type (class name) to match. Case-insensitive regex pattern.
+    /// Example: "JsonConfigurationProvider" or ".*Azure.*"
+    /// </summary>
+    public string? ProviderType { get; set; }
+
+    /// <summary>
+    /// Provider source (file name or identifier) to match. Case-insensitive regex pattern.
+    /// Example: "appsettings.Development.json" or ".*Development.*"
+    /// </summary>
+    public string? ProviderSource { get; set; }
+
+    /// <summary>
+    /// The redaction mode to apply
+    /// </summary>
+    public RedactionMode RedactionMode { get; set; }
+
+    /// <summary>
+    /// Additional options for Advanced redaction mode
+    /// </summary>
+    public RedactionOptions? RedactionOptions { get; set; }
+}
+
+/// <summary>
+/// Advanced redaction options
+/// </summary>
+public class RedactionOptions
+{
+    /// <summary>
+    /// Number of characters to keep visible at the start
+    /// </summary>
+    public int? KeepFirst { get; set; }
+
+    /// <summary>
+    /// Number of characters to keep visible at the end
+    /// </summary>
+    public int? KeepLast { get; set; }
+
+    /// <summary>
+    /// List of nested keys to redact (for complex values like connection strings)
+    /// </summary>
+    public List<string>? Keys { get; set; }
+}
+
+/// <summary>
+/// Redaction modes
+/// </summary>
+public enum RedactionMode
+{
+    /// <summary>
+    /// Completely replace the value with redaction characters
+    /// </summary>
+    Full,
+
+    /// <summary>
+    /// Show the first and last characters, redact the middle
+    /// </summary>
+    Partial,
+
+    /// <summary>
+    /// Apply custom redaction using RedactionOptions
+    /// </summary>
+    Advanced
+}

--- a/Cultiv.EnvironmentInspect/Cultiv.EnvironmentInspect.csproj
+++ b/Cultiv.EnvironmentInspect/Cultiv.EnvironmentInspect.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StaticWebAssetBasePath>/</StaticWebAssetBasePath>
+    <NoWarn>$(NoWarn);NU5118</NoWarn>
     
     <!-- Symbol file configuration -->
     <DebugType>portable</DebugType>
@@ -43,6 +44,8 @@
   <ItemGroup>
     <!-- Dont include the client folder as part of packaging nuget build -->
     <Content Remove="Client\**" />
+    <!-- Remove schema from default content items so we can explicitly control packaging -->
+    <Content Remove="appsettings-schema.Cultiv.EnvironmentInspect.json" />
 
     <!-- However make the Umbraco-package.json included for dotnet pack or nuget package and visible to the solution -->
     <None Include="Client\public\umbraco-package.json" Pack="false" />
@@ -53,6 +56,8 @@
 	  <None Include="../LICENSE" Pack="true" PackagePath="" />
 	  <None Include="../README.md" Pack="true" PackagePath="" />
 	  <None Include="../logo.png" Pack="true" PackagePath="" />
+	  <Content Include="buildTransitive\**" PackagePath="buildTransitive" />
+	  <Content Include="appsettings-schema.Cultiv.EnvironmentInspect.json" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/Cultiv.EnvironmentInspect/Services/EnvironmentInspectService.cs
+++ b/Cultiv.EnvironmentInspect/Services/EnvironmentInspectService.cs
@@ -1,7 +1,10 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core.Cache;
+using Cultiv.EnvironmentInspect.Configuration;
 
 namespace Cultiv.EnvironmentInspect.Services;
 
@@ -10,14 +13,21 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
     private readonly IConfiguration _configuration;
     private readonly IAppPolicyCache _runtimeCache;
     private readonly ILogger<EnvironmentInspectService> _logger;
+    private readonly IOptionsMonitor<EnvironmentInspectOptions> _options;
     private const string CacheKey = "Cultiv.EnvironmentInspect.ConfigData";
     private IDisposable? _changeTokenRegistration;
+    private IDisposable? _optionsChangeRegistration;
 
-    public EnvironmentInspectService(IConfiguration configuration, AppCaches appCaches, ILogger<EnvironmentInspectService> logger)
+    public EnvironmentInspectService(
+        IConfiguration configuration, 
+        AppCaches appCaches, 
+        ILogger<EnvironmentInspectService> logger,
+        IOptionsMonitor<EnvironmentInspectOptions> options)
     {
         _configuration = configuration;
         _runtimeCache = appCaches.RuntimeCache;
         _logger = logger;
+        _options = options;
 
         // Register for configuration change notifications
         if (_configuration is IConfigurationRoot configRoot)
@@ -46,6 +56,13 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
                     });
                 });
         }
+
+        // Register for options change notifications
+        _optionsChangeRegistration = _options.OnChange(opts =>
+        {
+            _logger.LogInformation("EnvironmentInspect options changed, clearing cache");
+            _runtimeCache.Clear(CacheKey);
+        });
     }
 
     public async Task<List<EnvironmentVariable>> GetEnvironmentDataAsync()
@@ -62,6 +79,14 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
 
         if (_configuration is not IConfigurationRoot configurationRoot) return environmentVariables;
 
+        // Get current options
+        var options = _options.CurrentValue;
+
+        // Compile regex patterns for exclusions
+        var excludePatterns = options.Exclude
+            .Select(pattern => new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled))
+            .ToList();
+
         // Adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.Configuration.Abstractions/src/ConfigurationRootExtensions.cs#L36
         void RecurseChildren(IEnumerable<IConfigurationSection> children)
         {
@@ -71,11 +96,16 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
 
                 if (valueAndProvider.Provider != null)
                 {
+                    var providerString = valueAndProvider.Provider.ToString();
+                    var (providerType, providerSource) = ParseProvider(providerString);
+
                     environmentVariables.Add(new EnvironmentVariable
                     {
                         Key = child.Path,
                         Value = valueAndProvider.Value,
-                        Provider = valueAndProvider.Provider?.ToString(),
+                        Provider = providerString,
+                        ProviderType = providerType,
+                        ProviderSource = providerSource,
                     });
                 }
                 else
@@ -91,6 +121,12 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
         }
 
         RecurseChildren(configurationRoot.GetChildren().Where(x => !string.IsNullOrEmpty(x.Path)));
+
+        // Apply exclusions
+        environmentVariables = ApplyExclusions(environmentVariables, excludePatterns, options);
+
+        // Apply redactions
+        environmentVariables = ApplyRedactions(environmentVariables, options);
 
         return environmentVariables;
     }
@@ -110,8 +146,295 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
         return (null, null);
     }
 
+    private static (string? ProviderType, string? ProviderSource) ParseProvider(string? provider)
+    {
+        if (string.IsNullOrWhiteSpace(provider))
+        {
+            return (null, null);
+        }
+
+        // Extract provider type (class name before first space or entire string if no space)
+        var providerType = provider.Split(' ', 2)[0];
+
+        // Extract provider source (content between single quotes)
+        // Example: "JsonConfigurationProvider for 'appsettings.Development.json' (Optional)*"
+        // Source would be: "appsettings.Development.json"
+        string? providerSource = null;
+        var match = Regex.Match(provider, @"'([^']+)'");
+        if (match.Success)
+        {
+            providerSource = match.Groups[1].Value;
+        }
+
+        return (providerType, providerSource);
+    }
+
+    private List<EnvironmentVariable> ApplyExclusions(
+        List<EnvironmentVariable> variables, 
+        List<Regex> excludePatterns, 
+        EnvironmentInspectOptions options)
+    {
+        return variables.Where(variable =>
+        {
+            // Check if key matches any exclusion pattern
+            if (excludePatterns.Any(pattern => pattern.IsMatch(variable.Key)))
+            {
+                return false;
+            }
+
+            // Check if we should exclude empty values
+            if (options.ExcludeEmptyValues && string.IsNullOrWhiteSpace(variable.Value))
+            {
+                return false;
+            }
+
+            return true;
+        }).ToList();
+    }
+
+    private List<EnvironmentVariable> ApplyRedactions(
+        List<EnvironmentVariable> variables, 
+        EnvironmentInspectOptions options)
+    {
+        foreach (var variable in variables)
+        {
+            // Find the first matching redaction rule
+            var rule = options.Redact.FirstOrDefault(r =>
+            {
+                var matches = new List<bool>();
+
+                // Check if rule matches by key pattern
+                if (!string.IsNullOrEmpty(r.Key))
+                {
+                    try
+                    {
+                        var regex = new Regex(r.Key, RegexOptions.IgnoreCase);
+                        matches.Add(regex.IsMatch(variable.Key));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Invalid regex pattern in redaction rule Key: {Pattern}", r.Key);
+                        return false;
+                    }
+                }
+
+                // Check if rule matches by provider
+                if (!string.IsNullOrEmpty(r.Provider) && !string.IsNullOrEmpty(variable.Provider))
+                {
+                    try
+                    {
+                        var regex = new Regex(r.Provider, RegexOptions.IgnoreCase);
+                        matches.Add(regex.IsMatch(variable.Provider));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Invalid regex pattern in redaction rule Provider: {Pattern}", r.Provider);
+                        return false;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(r.Provider))
+                {
+                    // Provider pattern specified but variable has no provider
+                    matches.Add(false);
+                }
+
+                // Check if rule matches by provider type
+                if (!string.IsNullOrEmpty(r.ProviderType) && !string.IsNullOrEmpty(variable.ProviderType))
+                {
+                    try
+                    {
+                        var regex = new Regex(r.ProviderType, RegexOptions.IgnoreCase);
+                        matches.Add(regex.IsMatch(variable.ProviderType));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Invalid regex pattern in redaction rule ProviderType: {Pattern}", r.ProviderType);
+                        return false;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(r.ProviderType))
+                {
+                    // ProviderType pattern specified but variable has no provider type
+                    matches.Add(false);
+                }
+
+                // Check if rule matches by provider source
+                if (!string.IsNullOrEmpty(r.ProviderSource) && !string.IsNullOrEmpty(variable.ProviderSource))
+                {
+                    try
+                    {
+                        var regex = new Regex(r.ProviderSource, RegexOptions.IgnoreCase);
+                        matches.Add(regex.IsMatch(variable.ProviderSource));
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Invalid regex pattern in redaction rule ProviderSource: {Pattern}", r.ProviderSource);
+                        return false;
+                    }
+                }
+                else if (!string.IsNullOrEmpty(r.ProviderSource))
+                {
+                    // ProviderSource pattern specified but variable has no provider source
+                    matches.Add(false);
+                }
+
+                // All specified patterns must match (AND logic)
+                return matches.Count > 0 && matches.All(m => m);
+            });
+
+            // Apply redaction if a rule was found
+            if (rule != null && !string.IsNullOrEmpty(variable.Value))
+            {
+                var originalValue = variable.Value;
+                var redactedValue = ApplyRedactionMode(originalValue, rule, options);
+                
+                // Only mark as redacted if the value actually changed
+                if (redactedValue != originalValue)
+                {
+                    variable.Value = redactedValue;
+                    variable.RedactedMode = rule.RedactionMode.ToString();
+                }
+            }
+        }
+
+        return variables;
+    }
+
+    private string ApplyRedactionMode(string value, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        return rule.RedactionMode switch
+        {
+            RedactionMode.Full => new string(options.RedactionCharacter[0], 8),
+            RedactionMode.Partial => ApplyPartialRedaction(value, options),
+            RedactionMode.Advanced => ApplyAdvancedRedaction(value, rule, options),
+            _ => value
+        };
+    }
+
+    private string ApplyPartialRedaction(string value, EnvironmentInspectOptions options)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length <= options.PartialVisibleChars * 2)
+        {
+            return new string(options.RedactionCharacter[0], value.Length);
+        }
+
+        var visibleChars = options.PartialVisibleChars;
+        var start = value[..visibleChars];
+        var end = value[^visibleChars..];
+        var middleLength = value.Length - (visibleChars * 2);
+        var middle = new string(options.RedactionCharacter[0], Math.Max(3, middleLength));
+
+        return $"{start}{middle}{end}";
+    }
+
+    private string ApplyAdvancedRedaction(string value, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        var redactionOptions = rule.RedactionOptions;
+        if (redactionOptions == null)
+        {
+            return new string(options.RedactionCharacter[0], 8);
+        }
+
+        // If Keys are specified, redact specific key-value pairs within the value (e.g., connection strings)
+        if (redactionOptions.Keys != null && redactionOptions.Keys.Any())
+        {
+            return RedactNestedKeys(value, rule, options);
+        }
+
+        // If KeepFirst/KeepLast are specified, show only those characters
+        if (redactionOptions.KeepFirst.HasValue || redactionOptions.KeepLast.HasValue)
+        {
+            var keepFirst = redactionOptions.KeepFirst ?? 0;
+            var keepLast = redactionOptions.KeepLast ?? 0;
+
+            if (value.Length <= keepFirst + keepLast)
+            {
+                return new string(options.RedactionCharacter[0], value.Length);
+            }
+
+            var start = keepFirst > 0 ? value[..keepFirst] : string.Empty;
+            var end = keepLast > 0 ? value[^keepLast..] : string.Empty;
+            var middleLength = value.Length - keepFirst - keepLast;
+            var middle = new string(options.RedactionCharacter[0], Math.Max(3, middleLength));
+
+            return $"{start}{middle}{end}";
+        }
+
+        return new string(options.RedactionCharacter[0], 8);
+    }
+
+    private string RedactNestedKeys(string value, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        // Handle common delimited formats (connection strings, key-value pairs)
+        var result = value;
+        var keysToRedact = rule.RedactionOptions?.Keys ?? new List<string>();
+
+        foreach (var key in keysToRedact)
+        {
+            // Try to match patterns like "Key=Value;" or "Key:Value;" or "Key: Value"
+            var patterns = new[]
+            {
+                $@"({Regex.Escape(key)}\s*=\s*)([^;]+)",
+                $@"({Regex.Escape(key)}\s*:\s*)([^;]+)",
+            };
+
+            foreach (var pattern in patterns)
+            {
+                try
+                {
+                    result = Regex.Replace(
+                        result,
+                        pattern,
+                        match => 
+                        {
+                            var keyPart = match.Groups[1].Value;
+                            var valuePart = match.Groups[2].Value;
+                            var redactedValue = RedactNestedValue(valuePart, rule, options);
+                            return $"{keyPart}{redactedValue}";
+                        },
+                        RegexOptions.IgnoreCase
+                    );
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error applying nested key redaction for key: {Key}", key);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private string RedactNestedValue(string value, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        var redactionOptions = rule.RedactionOptions;
+        
+        // If KeepFirst/KeepLast are specified, use partial redaction
+        if (redactionOptions?.KeepFirst.HasValue == true || redactionOptions?.KeepLast.HasValue == true)
+        {
+            var keepFirst = redactionOptions.KeepFirst ?? 0;
+            var keepLast = redactionOptions.KeepLast ?? 0;
+
+            if (value.Length <= keepFirst + keepLast)
+            {
+                return new string(options.RedactionCharacter[0], Math.Min(value.Length, 8));
+            }
+
+            var start = keepFirst > 0 ? value[..keepFirst] : string.Empty;
+            var end = keepLast > 0 ? value[^keepLast..] : string.Empty;
+            var middleLength = value.Length - keepFirst - keepLast;
+            var middle = new string(options.RedactionCharacter[0], Math.Max(3, Math.Min(middleLength, 8)));
+
+            return $"{start}{middle}{end}";
+        }
+
+        // Default: full redaction with fixed length
+        return new string(options.RedactionCharacter[0], 8);
+    }
+
     public void Dispose()
     {
         _changeTokenRegistration?.Dispose();
+        _optionsChangeRegistration?.Dispose();
     }
 }

--- a/Cultiv.EnvironmentInspect/Services/IEnvironmentInspectService.cs
+++ b/Cultiv.EnvironmentInspect/Services/IEnvironmentInspectService.cs
@@ -10,4 +10,7 @@ public class EnvironmentVariable
     public required string Key { get; set; }
     public string? Value { get; set; }
     public string? Provider { get; set; }
+    public string? ProviderType { get; set; }
+    public string? ProviderSource { get; set; }
+    public string? RedactedMode { get; set; }
 }

--- a/Cultiv.EnvironmentInspect/appsettings-schema.Cultiv.EnvironmentInspect.json
+++ b/Cultiv.EnvironmentInspect/appsettings-schema.Cultiv.EnvironmentInspect.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/nul800sebastiaan/Cultiv.EnvironmentInspect/develop/v2/Cultiv.EnvironmentInspect/appsettings-schema.Cultiv.EnvironmentInspect.json",
+  "title": "Cultiv Environment Inspector Configuration",
+  "description": "Configuration schema for Cultiv.EnvironmentInspect package",
+  "type": "object",
+  "properties": {
+    "EnvironmentInspect": {
+      "type": "object",
+      "description": "Configuration for the Environment Inspector package",
+      "properties": {
+        "Exclude": {
+          "type": "array",
+          "description": "List of regex patterns for configuration keys to exclude entirely from the display",
+          "items": {
+            "type": "string",
+            "description": "Regex pattern to match configuration keys (e.g., '^APPSETTING_' to exclude environment variables)"
+          },
+          "examples": [
+            [
+              "^APPSETTING_",
+              "^AZURE_",
+              "^EnvironmentInspect",
+              "^\\$schema$"
+            ]
+          ]
+        },
+        "Redact": {
+          "type": "array",
+          "description": "List of redaction rules to apply to configuration values. Rules are processed in order, and the first match is applied.",
+          "items": {
+            "type": "object",
+            "description": "A redaction rule that matches by Key, Provider, ProviderType, or ProviderSource. Multiple properties can be combined (AND logic).",
+            "properties": {
+              "Key": {
+                "type": "string",
+                "description": "Regex pattern to match configuration keys"
+              },
+              "Provider": {
+                "type": "string",
+                "description": "Regex pattern to match the full configuration provider name (e.g., 'JsonConfigurationProvider for \\'appsettings.json\\' (Optional)')"
+              },
+              "ProviderType": {
+                "type": "string",
+                "description": "Regex pattern to match the provider type (class name only, e.g., 'JsonConfigurationProvider' or '.*Azure.*')"
+              },
+              "ProviderSource": {
+                "type": "string",
+                "description": "Regex pattern to match the provider source (file name or identifier, e.g., 'appsettings.Development.json' or '.*Development.*')"
+              },
+              "RedactionMode": {
+                "type": "string",
+                "description": "The type of redaction to apply",
+                "enum": [
+                  "Full",
+                  "Partial",
+                  "Advanced"
+                ],
+                "default": "Full"
+              },
+              "RedactionOptions": {
+                "type": "object",
+                "description": "Additional options for Advanced redaction mode",
+                "properties": {
+                  "KeepFirst": {
+                    "type": "integer",
+                    "description": "Number of characters to keep visible at the start of the value",
+                    "minimum": 0,
+                    "default": 0
+                  },
+                  "KeepLast": {
+                    "type": "integer",
+                    "description": "Number of characters to keep visible at the end of the value",
+                    "minimum": 0,
+                    "default": 0
+                  },
+                  "Keys": {
+                    "type": "array",
+                    "description": "List of nested keys to redact within the value (useful for connection strings)",
+                    "items": {
+                      "type": "string",
+                      "description": "Key name to extract and redact (e.g., 'Password', 'PWD', 'User Id')"
+                    },
+                    "examples": [
+                      [
+                        "Password",
+                        "PWD",
+                        "User Id",
+                        "UID"
+                      ]
+                    ]
+                  }
+                }
+              }
+            },
+            "anyOf": [
+              {
+                "required": [
+                  "Key"
+                ]
+              },
+              {
+                "required": [
+                  "Provider"
+                ]
+              },
+              {
+                "required": [
+                  "ProviderType"
+                ]
+              },
+              {
+                "required": [
+                  "ProviderSource"
+                ]
+              }
+            ],
+            "required": [
+              "RedactionMode"
+            ]
+          },
+          "examples": [
+            [
+              {
+                "Key": ".*Password$",
+                "RedactionMode": "Full"
+              },
+              {
+                "Key": "ConnectionStrings:.*",
+                "RedactionMode": "Advanced",
+                "RedactionOptions": {
+                  "Keys": [
+                    "Password",
+                    "PWD"
+                  ],
+                  "KeepFirst": 2,
+                  "KeepLast": 2
+                }
+              },
+              {
+                "ProviderSource": ".*Development.*",
+                "RedactionMode": "Partial"
+              },
+              {
+                "ProviderType": "AzureKeyVaultConfigurationProvider",
+                "RedactionMode": "Full"
+              }
+            ]
+          ]
+        },
+        "RedactionCharacter": {
+          "type": "string",
+          "description": "The character to use for redaction",
+          "default": "•",
+          "minLength": 1,
+          "maxLength": 1
+        },
+        "PartialVisibleChars": {
+          "type": "integer",
+          "description": "Number of characters to show at the start and end in Partial redaction mode",
+          "default": 4,
+          "minimum": 1,
+          "maximum": 10
+        },
+        "ExcludeEmptyValues": {
+          "type": "boolean",
+          "description": "Whether to exclude configuration keys with null or empty values from the display",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/Cultiv.EnvironmentInspect/buildTransitive/Cultiv.EnvironmentInspect.props
+++ b/Cultiv.EnvironmentInspect/buildTransitive/Cultiv.EnvironmentInspect.props
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup>
+		<UmbracoJsonSchemaFiles Include="$(MSBuildThisFileDirectory)..\appsettings-schema.Cultiv.EnvironmentInspect.json" Weight="-50" />
+	</ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cultiv.EnvironmentInspect &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![NuGet version (Cultiv.EnvironmentInspect)](https://img.shields.io/nuget/v/Cultiv.EnvironmentInspect.svg)](https://www.nuget.org/packages/Cultiv.EnvironmentInspect/) [![Twitter](https://img.shields.io/twitter/follow/cultiv.svg?style=social&label=Follow)](https://twitter.com/intent/follow?screen_name=cultiv)
+# Cultiv.EnvironmentInspect &middot; [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE) [![NuGet version (Cultiv.EnvironmentInspect)](https://img.shields.io/nuget/v/Cultiv.EnvironmentInspect.svg)](https://www.nuget.org/packages/Cultiv.EnvironmentInspect/) [![CI](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect/actions/workflows/ci.yml/badge.svg)](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect/actions)
 
 **v1 is for Umbraco v9 to v13**  
 **v2 is for Umbraco v17+**
@@ -34,9 +34,17 @@ Or via the NuGet Package Manager Console:
 Install-Package Cultiv.EnvironmentInspect
 ```
 
-## Quick Configuration
+## Usage
 
-Add the `EnvironmentInspect` section to your `appsettings.json`:
+1. Install the package
+2. Access the dashboard in **Settings → Environment Inspector**
+3. View all configuration values and their sources
+
+That's it! The package works out of the box with no configuration required.
+
+## Configuration (Optional)
+
+If you need to exclude or redact sensitive values, add the `EnvironmentInspect` section to your `appsettings.json`:
 
 ```json
 {
@@ -92,13 +100,6 @@ Add the `EnvironmentInspect` section to your `appsettings.json`:
 - Keys matching `.*Secret.*`: `••••••••` 🔒
 
 For detailed configuration options, see the [Configuration Guide](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect/blob/develop/v2/CONFIGURATION.md).
-
-## Usage
-
-1. Install the package
-2. Access the dashboard in **Settings → Environment Inspector**
-3. View all configuration values and their sources
-4. Configure exclusions and redactions in `appsettings.json` as needed
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,111 @@
 
 Cultiv Environment Inspector installs a dashboard in the Settings section of Umbraco, showing you the currently applied environment values and where they are coming from.
 
-For example, we can see some of the values here are coming from `appSetting.json` and `appSetting.Development.json`. 
+For example, we can see some of the values here are coming from `appsetting.json` and `appsetting.Development.json`. 
 
-![Screenshot with an example of some variables, values and their sources](http://raw.githubusercontent.com/nul800sebastiaan/Cultiv.EnvironmentInspect/main/example.png)
+![Screenshot with an example of some variables, values and their sources](http://raw.githubusercontent.com/nul800sebastiaan/Cultiv.EnvironmentInspect/develop/v2/example.png)
 
 This makes it easier to learn why some variables you expected to work have not been applied.
+
+## Features
+
+- 📊 **View all configuration values** and their sources in the Umbraco backoffice
+- 🔒 **Redact sensitive data** with multiple redaction modes (Full, Partial, Advanced)
+- 🎯 **Exclude configuration keys** using regex patterns
+- 🔐 **Provider-based filtering** - match by provider type, source file, or full name
+- 🚀 **Performance optimized** with runtime caching and change detection
+- 🔄 **Hot reload support** - configuration changes are automatically applied
+
+## Installation
+
+Install via NuGet:
+
+```bash
+dotnet add package Cultiv.EnvironmentInspect
+```
+
+Or via the NuGet Package Manager Console:
+
+```powershell
+Install-Package Cultiv.EnvironmentInspect
+```
+
+## Quick Configuration
+
+Add the `EnvironmentInspect` section to your `appsettings.json`:
+
+```json
+{
+  "EnvironmentInspect": {
+    "Exclude": [
+      "^APPSETTING_",
+      "^AZURE_",
+      "^EnvironmentInspect",
+      "^\\$schema$"
+    ],
+    "Redact": [
+      {
+        "Key": "Umbraco:CMS:Unattended:UnattendedUserPassword",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": "ConnectionStrings:.*",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ "Password", "PWD" ],
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
+        "Key": ".*Password$",
+        "RedactionMode": "Full"
+      },
+      {
+        "Key": ".*Secret.*",
+        "RedactionMode": "Full"
+      },
+      {
+        "ProviderType": "AzureKeyVaultConfigurationProvider",
+        "RedactionMode": "Full"
+      }
+    ],
+    "RedactionCharacter": "•",
+    "PartialVisibleChars": 4,
+    "ExcludeEmptyValues": false
+  }
+}
+```
+
+**Results:**
+- `UnattendedUserPassword`: `12••••90` 🔐
+- Connection string password: `7R••••($` (extracted from connection string) 🔐
+- Keys matching `.*Password$`: `••••••••` 🔒
+- Keys matching `.*Secret.*`: `••••••••` 🔒
+
+For detailed configuration options, see the [Configuration Guide](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect/blob/develop/v2/CONFIGURATION.md).
+
+## Usage
+
+1. Install the package
+2. Access the dashboard in **Settings → Environment Inspector**
+3. View all configuration values and their sources
+4. Configure exclusions and redactions in `appsettings.json` as needed
+
+## Documentation
+
+- **[Configuration Guide](https://github.com/nul800sebastiaan/Cultiv.EnvironmentInspect/blob/develop/v2/CONFIGURATION.md)** - Detailed configuration options, examples, and best practices
+
+## Best Practices
+
+1. **Order matters**: Place specific redaction rules before general ones
+2. **Test regex patterns**: Use [regex101.com](https://regex101.com/) to validate your patterns
+3. **Use Advanced mode for connection strings**: Extract and redact only the sensitive parts
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This pull request introduces a flexible and configurable system for excluding and redacting sensitive configuration values in the Environment Inspect feature. It adds a new strongly-typed options class for configuration, updates the backend service to apply exclusion and redaction rules, and enhances the frontend to visually indicate redacted values. Additionally, it improves packaging and configuration management.

**Configuration and Redaction System:**

* Introduced `EnvironmentInspectOptions` and related classes (`RedactionRule`, `RedactionOptions`, `RedactionMode`) to allow exclusion and redaction of sensitive configuration keys, supporting advanced and customizable rules via regular expressions and provider metadata. (`Cultiv.EnvironmentInspect/Configuration/EnvironmentInspectOptions.cs`)
* Updated `appsettings.json` to include an `EnvironmentInspect` section with example exclusion and redaction rules, and added sample sensitive values and Azure connection strings for demonstration. (`Cultiv.EnvironmentInspect.DemoSite/appsettings.json`)

**Backend Service Enhancements:**

* Modified `EnvironmentInspectService` to use the new options class, automatically clear cache on configuration changes, and apply exclusion and redaction logic to collected environment variables. Also extracts provider type/source info for each variable. (`Cultiv.EnvironmentInspect/Services/EnvironmentInspectService.cs`) [[1]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR1-R7) [[2]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR16-R30) [[3]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR59-R65) [[4]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR82-R89) [[5]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR99-R108) [[6]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR125-R130)
* Registered the options class with dependency injection in the composer. (`Cultiv.EnvironmentInspect/Composers/CultivEnvironmentInspectComposer.cs`) [[1]](diffhunk://#diff-9e8923d11f969a46219195ceb17596cb857cbfc9bdcf363564b2b59140eb8286R16) [[2]](diffhunk://#diff-9e8923d11f969a46219195ceb17596cb857cbfc9bdcf363564b2b59140eb8286R26-R29)

**Frontend Improvements:**

* Updated the dashboard UI to display a visual emoji indicator for each redacted value, with different icons for full, partial, and advanced redaction modes. Also improved table cell styling for better readability. (`Cultiv.EnvironmentInspect/Client/src/dashboards/dashboard.ts`) [[1]](diffhunk://#diff-bd13be5369440f1478e35319049dfe3df2bfbb05f569dc009979c33af67251a6R22-R34) [[2]](diffhunk://#diff-bd13be5369440f1478e35319049dfe3df2bfbb05f569dc009979c33af67251a6L43-R62) [[3]](diffhunk://#diff-bd13be5369440f1478e35319049dfe3df2bfbb05f569dc009979c33af67251a6R166-R173)

**Packaging and Build:**

* Adjusted the project file to control packaging of schema and build assets, and suppressed a NuGet warning. (`Cultiv.EnvironmentInspect/Cultiv.EnvironmentInspect.csproj`) [[1]](diffhunk://#diff-4c280047fcf66f729b8332283b5b9f279e67a996417222eb9d45cce2c9ec8b97R7) [[2]](diffhunk://#diff-4c280047fcf66f729b8332283b5b9f279e67a996417222eb9d45cce2c9ec8b97R47-R48) [[3]](diffhunk://#diff-4c280047fcf66f729b8332283b5b9f279e67a996417222eb9d45cce2c9ec8b97R59-R60)