### PR TITLE
Add JSON-aware redaction for nested configuration values

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,215 @@
+# Cultiv.EnvironmentInspect Development Guidelines
+
+## Project Overview
+
+Cultiv Environment Inspector is an Umbraco CMS package (v17+) that provides a dashboard in the Settings section showing all configuration values and their sources (appsettings.json, environment variables, Azure Key Vault, etc.).
+
+**Key Technologies:**
+- **Backend**: ASP.NET Core (net10.0), Umbraco CMS v17+, EF Core
+- **Frontend**: TypeScript, Vue.js, Vite (in `/Client` folder)
+- **Database**: SQLite and SQL Server supported (migrations via EF Core)
+- **Build**: GitHub Actions CI/CD, NuGet package publishing
+
+## Project Structure
+
+```
+Cultiv.EnvironmentInspect/           # Main package
+  ├── Client/                         # Frontend (TypeScript/Vue/Vite)
+  ├── Services/                       # Core business logic
+  │   └── EnvironmentInspectService.cs
+  ├── Controllers/                    # Web API endpoints
+  ├── Data/                           # EF Core DbContext and entities
+  ├── Migrations/                     # EF Core migrations
+  ├── Configuration/                  # Options classes
+  ├── Composers/                      # Umbraco composers
+  └── wwwroot/                        # Built frontend assets
+
+Cultiv.EnvironmentInspect.DemoSite/  # Test site for local development
+```
+
+## Coding Standards
+
+### C# Code
+
+**Formatting:**
+- Run `dotnet format` after making changes
+- Use 4-space indentation (not tabs)
+- Line endings: CRLF (Windows)
+- Follow existing code patterns in the file you're editing
+
+**Patterns to Follow:**
+- Use dependency injection for services
+- Log important operations with `ILogger<T>`
+- Handle errors gracefully with try-catch and logging
+- Use nullable reference types (`#nullable enable`)
+- Use implicit usings (configured in project)
+
+**Example Service Pattern:**
+```csharp
+public class MyService : IMyService
+{
+    private readonly ILogger<MyService> _logger;
+    private readonly IConfiguration _configuration;
+
+    public MyService(
+        ILogger<MyService> logger,
+        IConfiguration configuration)
+    {
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    public string ProcessData(string input)
+    {
+        try
+        {
+            // Implementation
+            _logger.LogInformation("Successfully processed data");
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error processing data: {Input}", input);
+            throw;
+        }
+    }
+}
+```
+
+### TypeScript/Frontend
+
+The frontend is in the `Client/` folder and uses:
+- TypeScript with strict mode
+- Vue.js for UI components
+- Vite for building
+- ESLint for linting
+
+Build the frontend with:
+```bash
+cd Cultiv.EnvironmentInspect/Client
+npm run build
+```
+
+## Configuration & Documentation
+
+### Adding New Features
+
+When adding new redaction modes, configuration options, or features:
+
+1. **Update the code** in the appropriate service/controller
+2. **Update `CONFIGURATION.md`** with:
+   - New configuration options in the reference table
+   - Example JSON configuration snippets
+   - Input/output examples showing the feature in action
+3. **Update `README.md`** if it's a user-facing feature
+4. **Consider adding to `appsettings-schema.Cultiv.EnvironmentInspect.json`** for IntelliSense
+
+### Configuration Documentation Pattern
+
+When documenting redaction/exclusion rules in `CONFIGURATION.md`:
+```markdown
+*Option X: Description of the feature*
+```json
+{
+  "Key": "pattern",
+  "RedactionMode": "Mode",
+  "RedactionOptions": { /* options */ }
+}
+```
+Input: `example input string`  
+Result: `example output with redaction`
+```
+
+**Use fake data in examples:**
+- Use `example-server.database.windows.net` for servers
+- Use `S3cr3tP@ssw0rd!XyZ` style for passwords
+- Use random GUIDs like `a1b2c3d4-5678-9abc-def0-123456789abc`
+- Avoid real organization names or credentials
+
+## Building & Testing
+
+### Build Commands
+
+```bash
+# Build the entire solution
+dotnet build
+
+# Build just the package
+dotnet build Cultiv.EnvironmentInspect/Cultiv.EnvironmentInspect.csproj
+
+# Format code (required before committing)
+dotnet format
+
+# Verify formatting
+dotnet format --verify-no-changes
+
+# Run the demo site
+cd Cultiv.EnvironmentInspect.DemoSite
+dotnet run
+```
+
+### Running Locally
+
+1. Start the demo site: `dotnet run` in `Cultiv.EnvironmentInspect.DemoSite/`
+2. Access Umbraco at `https://localhost:5001` (or configured port)
+3. Navigate to **Settings → Environment Inspector**
+
+### Database Migrations
+
+If you modify the `UserPreference` entity or add new entities:
+
+```bash
+cd Cultiv.EnvironmentInspect
+dotnet ef migrations add MigrationName --startup-project ../Cultiv.EnvironmentInspect.DemoSite
+```
+
+## CI/CD
+
+The project uses GitHub Actions:
+- **`ci.yml`**: Builds, tests, formats check
+- **`release.yml`**: Creates GitHub releases and publishes to NuGet
+
+Code must pass `dotnet format --verify-no-changes` in CI.
+
+## Common Tasks
+
+### Adding a New Redaction Mode
+
+1. Update `EnvironmentInspectOptions.cs` with new options
+2. Implement logic in `EnvironmentInspectService.cs` (e.g., in `ApplyRedaction()` or `RedactNestedKeys()`)
+3. Add example to `CONFIGURATION.md` showing input/output
+4. Update schema file if needed
+5. Run `dotnet format`
+6. Test with demo site
+
+### Adding a New Configuration Option
+
+1. Add property to `EnvironmentInspectOptions.cs`
+2. Document in `CONFIGURATION.md` reference table
+3. Add example usage
+4. Update `appsettings-schema.Cultiv.EnvironmentInspect.json`
+5. Update demo site's `appsettings.json` with example
+
+### Modifying API Endpoints
+
+Controllers are in `Controllers/` folder. Follow REST conventions:
+- Use attribute routing: `[Route("api/environmentinspect/[action]")]`
+- Return appropriate status codes
+- Document with XML comments for Swagger
+- Handle errors and log them
+
+## Anti-Patterns to Avoid
+
+❌ **Don't** commit code that fails `dotnet format`  
+❌ **Don't** use real credentials or organization names in examples  
+❌ **Don't** add features without updating `CONFIGURATION.md`  
+❌ **Don't** use tabs for indentation (use 4 spaces)  
+❌ **Don't** ignore logger warnings - they indicate potential issues  
+❌ **Don't** modify migrations after they've been committed  
+
+## Getting Help
+
+- Check `CONFIGURATION.md` for redaction/exclusion patterns
+- Review existing service patterns in `Services/EnvironmentInspectService.cs`
+- See `README.md` for user-facing feature documentation
+- Check `.github/workflows/` for CI/CD pipeline details

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -119,8 +119,25 @@ Result: `12••••90`
   }
 }
 ```
-Input: `Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R9K8sS*@G2$JmpeQs($;Connection Timeout=120;`  
-Result: `Server=blaa.database.windows.net,1433;Database=22sa1bmi2ye;User ID=ypad0yvmodr@blaa;Password=7R••••($;Connection Timeout=120;`
+Input: `Server=example-server.database.windows.net,1433;Database=myDatabase;User ID=dbuser@example;Password=S3cr3tP@ssw0rd!XyZ;Connection Timeout=120;`  
+Result: `Server=example-server.database.windows.net,1433;Database=myDatabase;User ID=dbuser@example;Password=S3••••yZ;Connection Timeout=120;`
+
+*Option C: Extract and redact keys from JSON values*
+```json
+{
+  "Key": "^UMBRACO:CLOUD:EXTERNALLOGINPROVIDER:\\d+$",
+  "RedactionMode": "Advanced",
+  "RedactionOptions": {
+    "Keys": [ "ClientSecret" ],
+    "KeepFirst": 2,
+    "KeepLast": 2
+  }
+}
+```
+Input: `{"Id":"a1b2c3d4-5678-9abc-def0-123456789abc","Name":"Example SSO Provider","Alias":"example-sso",...,"Settings":{"ClientId":"abcd1234-5678-90ef-ghij-klmnopqrstuv","ClientSecret":"Abc123~DefGhiJklMnoPqrStUvWxYz0123456789","Authority":"https://login.example.com/..."}}`  
+Result: `{"Id":"a1b2c3d4-5678-9abc-def0-123456789abc","Name":"Example SSO Provider","Alias":"example-sso",...,"Settings":{"ClientId":"abcd1234-5678-90ef-ghij-klmnopqrstuv","ClientSecret":"Ab••••89","Authority":"https://login.example.com/..."}}`
+
+The Advanced mode with `Keys` automatically detects if the value is JSON and parses it to redact only the specified keys, leaving other properties visible. This works for both simple JSON objects and nested structures.
 
 #### Provider-Based Redaction
 

--- a/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
+++ b/Cultiv.EnvironmentInspect.DemoSite/appsettings.json
@@ -63,6 +63,15 @@
         }
       },
       {
+        "Key": "^UMBRACO:CLOUD:EXTERNALLOGINPROVIDER:\\d+$",
+        "RedactionMode": "Advanced",
+        "RedactionOptions": {
+          "Keys": [ "ClientSecret" ],
+          "KeepFirst": 2,
+          "KeepLast": 2
+        }
+      },
+      {
         "Key": "ConnectionStrings:.*",
         "RedactionMode": "Advanced",
         "RedactionOptions": {

--- a/Cultiv.EnvironmentInspect/Services/EnvironmentInspectService.cs
+++ b/Cultiv.EnvironmentInspect/Services/EnvironmentInspectService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -456,9 +457,23 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
 
     private string RedactNestedKeys(string value, RedactionRule rule, EnvironmentInspectOptions options)
     {
+        var keysToRedact = rule.RedactionOptions?.Keys ?? new List<string>();
+
+        // Try to handle as JSON first
+        if (IsJson(value))
+        {
+            try
+            {
+                return RedactJsonKeys(value, keysToRedact, rule, options);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error parsing JSON for redaction, falling back to string patterns");
+            }
+        }
+
         // Handle common delimited formats (connection strings, key-value pairs)
         var result = value;
-        var keysToRedact = rule.RedactionOptions?.Keys ?? new List<string>();
 
         foreach (var key in keysToRedact)
         {
@@ -494,6 +509,90 @@ public class EnvironmentInspectService : IEnvironmentInspectService, IDisposable
         }
 
         return result;
+    }
+
+    private bool IsJson(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        value = value.Trim();
+        return (value.StartsWith("{") && value.EndsWith("}")) ||
+               (value.StartsWith("[") && value.EndsWith("]"));
+    }
+
+    private string RedactJsonKeys(string json, List<string> keysToRedact, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        // Use a dictionary to build the redacted JSON
+        var redacted = RedactJsonElement(root, keysToRedact, rule, options);
+
+        // Serialize back to JSON string with the same formatting style (compact)
+        return JsonSerializer.Serialize(redacted, new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        });
+    }
+
+    private object? RedactJsonElement(JsonElement element, List<string> keysToRedact, RedactionRule rule, EnvironmentInspectOptions options)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                var obj = new Dictionary<string, object?>();
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (keysToRedact.Any(k => string.Equals(k, property.Name, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        // Redact this property value
+                        var originalValue = property.Value.ValueKind == JsonValueKind.String
+                            ? property.Value.GetString() ?? string.Empty
+                            : property.Value.GetRawText();
+                        obj[property.Name] = RedactNestedValue(originalValue, rule, options);
+                    }
+                    else
+                    {
+                        // Recursively process nested objects/arrays
+                        obj[property.Name] = RedactJsonElement(property.Value, keysToRedact, rule, options);
+                    }
+                }
+                return obj;
+
+            case JsonValueKind.Array:
+                var arr = new List<object?>();
+                foreach (var item in element.EnumerateArray())
+                {
+                    arr.Add(RedactJsonElement(item, keysToRedact, rule, options));
+                }
+                return arr;
+
+            case JsonValueKind.String:
+                return element.GetString();
+
+            case JsonValueKind.Number:
+                if (element.TryGetInt32(out var intValue))
+                    return intValue;
+                if (element.TryGetInt64(out var longValue))
+                    return longValue;
+                if (element.TryGetDouble(out var doubleValue))
+                    return doubleValue;
+                return element.GetRawText();
+
+            case JsonValueKind.True:
+                return true;
+
+            case JsonValueKind.False:
+                return false;
+
+            case JsonValueKind.Null:
+                return null;
+
+            default:
+                return element.GetRawText();
+        }
     }
 
     private string RedactNestedValue(string value, RedactionRule rule, EnvironmentInspectOptions options)


### PR DESCRIPTION
Enables the service to detect JSON strings and redact specific keys within the parsed structure while preserving the surrounding data. This provides a more reliable way to mask sensitive properties in complex configuration objects compared to simple pattern-based matching.
This pull request introduces advanced support for redacting sensitive keys within JSON configuration values, improving both the backend logic and the documentation. The main enhancement is the ability to automatically detect JSON values and redact only specified keys, leaving other properties visible. Additionally, the documentation and demo configuration are updated to illustrate and support this new feature.

**Backend enhancements:**

* Added logic to detect if a configuration value is JSON and, if so, parse it and redact only the specified sensitive keys (e.g., `ClientSecret`) using the new `RedactJsonKeys` and `RedactJsonElement` methods in `EnvironmentInspectService.cs`. This ensures precise redaction for both simple and nested JSON structures. [[1]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR460-L461) [[2]](diffhunk://#diff-b3d7aa19750bf68c2784e53ecb12cde48a50650cbe28a014d6c70f379561cf7eR514-R597)
* Imported `System.Text.Json` to enable JSON parsing and serialization for redaction purposes in `EnvironmentInspectService.cs`.

**Configuration and documentation updates:**

* Updated the demo site's `appsettings.json` to include a sample redaction rule for JSON values, specifically targeting the `ClientSecret` key in external login provider settings.
* Expanded `CONFIGURATION.md` with examples of the new JSON key redaction feature, including realistic sample input/output and guidance on using fake data in documentation.